### PR TITLE
fix: dismiss update banner before reload

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -975,7 +975,10 @@ export default function App() {
       {/* ── SW Update Banner ── */}
       {needRefresh && !dismissedUpdate && (
         <PWAUpdateBanner
-          onUpdate={applyUpdate}
+          onUpdate={() => {
+            setDismissedUpdate(true);
+            applyUpdate();
+          }}
           onDismiss={() => setDismissedUpdate(true)}
         />
       )}


### PR DESCRIPTION
The banner will now be dismissed before the page reloads, so it won't reappear after the update is applied.